### PR TITLE
Adjusts worker caption fallback

### DIFF
--- a/src/utils/convertWorkerName.ts
+++ b/src/utils/convertWorkerName.ts
@@ -41,8 +41,8 @@ export const convertWorkerName = (
   // Construct the href with proper format
   const href = `https://${domain}/@${username}${workerPart ? `#${workerPart}` : ''}`;
 
-  // Caption: show only the worker name (e.g. "Pontus") for list and details; no @user@domain prefix
-  const caption = workerPart ?? `@${username}@${domain}`;
+  // Caption: worker name (e.g. "Pontus") when defined; otherwise fediverse username only (e.g. "@catchthatrabbit")
+  const caption = workerPart ?? `@${username}`;
 
   // Fediverse handle for link text (e.g. "@catchthatrabbit@coretalk.space")
   const fediverseHandle = `@${username}@${domain}`;


### PR DESCRIPTION
Updates the logic for the worker caption to display only the fediverse username when a specific worker name is not defined. This provides a more concise fallback compared to showing the full fediverse handle.